### PR TITLE
fix: support ':' character in scope names

### DIFF
--- a/src/clog.rs
+++ b/src/clog.rs
@@ -156,7 +156,7 @@ impl Clog {
             out_format: ChangelogFormat::Markdown,
             git_dir: None,
             git_work_tree: None,
-            regex: regex!(r"^([^:\(]+?)(?:\(([^:\)]*?)?\))?:(.*)"),
+            regex: regex!(r"^([^:\(]+?)(?:\(([^\)]*?)?\))?:(.*)"),
             closes_regex: regex!(r"(?:Closes|Fixes|Resolves)\s((?:#(\d+)(?:,\s)?)+)"),
             breaks_regex: regex!(r"(?:Breaks|Broke)\s((?:#(\d+)(?:,\s)?)+)"),
             breaking_regex: regex!(r"(?i:breaking)")


### PR DESCRIPTION
Change the regex for parsing commit headers so that colons in scope names
don't break parsing. Commit headers like "feat(foo::bar): change" are no
longer excluded from the generated changelist.