### PR TITLE
fix: Make parse_raw_commit public

### DIFF
--- a/src/clog.rs
+++ b/src/clog.rs
@@ -782,6 +782,7 @@ impl Clog {
                 .collect()
     }
 
+    #[doc(hidden)]
     pub fn parse_raw_commit(&self, commit_str: &str) -> Commit {
         let mut lines = commit_str.lines();
 

--- a/src/clog.rs
+++ b/src/clog.rs
@@ -782,7 +782,7 @@ impl Clog {
                 .collect()
     }
 
-    fn parse_raw_commit(&self, commit_str: &str) -> Commit {
+    pub fn parse_raw_commit(&self, commit_str: &str) -> Commit {
         let mut lines = commit_str.lines();
 
         let hash = lines.next().unwrap_or("").to_owned();


### PR DESCRIPTION
For a project I need to parse git commits I extracted using libgit2. Right now we're using a fork of `clog-lib` with this change.
In the long run it would be nicer to simply use an upstream version with this change.

Would you be willing to mark this function as public?

/cc @schultyy 