### PR TITLE
refactor: Remove dependency on regex_macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,8 @@ regex = "0.1.41"
 toml = "0.1.23"
 time = "0.1.33"
 
-[dependencies.regex_macros]
-version = "*"
-optional = true
-
 [features]
 default = []
 
 # For debugging output
 debug = []
-
-# for building with nightly and unstable features
-# until regex_macros compiles with nightly again, this should be commented out
-# unstable = ["regex_macros"]
-unstable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ default = []
 
 # For debugging output
 debug = []
+unstable = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,3 @@
-// Until regex_macros compiles on nightly, we comment this out
-//
-// #![cfg_attr(feature = "unstable", feature(plugin))]
-// #![cfg_attr(feature = "unstable", plugin(regex_macros))]
-
 // DOCS
 
 extern crate regex;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,9 +13,6 @@ macro_rules! werr(
     })
 );
 
-// regex cheat thanks to https://github.com/BurntSushi
-// Until regex_macros compiles with nightly again, this directive should be commented out
-// #[cfg(not(unstable))]
 macro_rules! regex(
     ($s:expr) => (::regex::Regex::new($s).unwrap());
 );


### PR DESCRIPTION
It was not used in stable at all, because it only works in nightly.
Now that regex! is almost always slower¹ there's no reason to keep it in.

¹: https://github.com/rust-lang-nursery/regex/pull/164