### PR TITLE
feat(LinkStyle): Add `Gitweb` style

### DIFF
--- a/src/link_style.rs
+++ b/src/link_style.rs
@@ -13,7 +13,8 @@ clog_enum!{
         Github,
         Gitlab,
         Stash,
-        Cgit
+        Cgit,
+        Gitweb
     }
 }
 
@@ -39,6 +40,8 @@ impl LinkStyle {
                     LinkStyle::Stash => format!("{}", issue.as_ref()),
                     // cgit does not support issues
                     LinkStyle::Cgit => format!("{}", issue.as_ref()),
+                    // gitweb does not support issues
+                    LinkStyle::Gitweb => format!("{}", issue.as_ref()),
                 }
             }
         }
@@ -54,6 +57,17 @@ impl LinkStyle {
     ///
     /// assert_eq!("https://github.com/thoughtram/clog/commit/123abc891234567890abcdefabc4567898724", commit);
     /// ```
+    ///
+    /// # Example
+    /// Note that for `LinkStyle::Gitweb` the actual repository name has to be given as part of the parameter string of the URL:
+    ///
+    /// ```no_run
+    /// # use clog::{LinkStyle, Clog};
+    /// let link = LinkStyle::Gitweb;
+    /// let commit = link.commit_link("deadbeef", "http://example.com/gitweb/?p=foo.git");
+    ///
+    /// assert_eq!("http://example.com/gitweb/?p=foo.git;a=commit;h=deadbeef", commit);
+    /// ```
     pub fn commit_link<S: AsRef<str>>(&self, hash: S, repo: S) -> String {
         match repo.as_ref() {
             "" => format!("{}", &hash.as_ref()[0..8]),
@@ -63,8 +77,29 @@ impl LinkStyle {
                     LinkStyle::Gitlab => format!("{}/commit/{}", link, hash.as_ref()),
                     LinkStyle::Stash => format!("{}/commits/{}", link, hash.as_ref()),
                     LinkStyle::Cgit => format!("{}/commit/?id={}", link, hash.as_ref()),
+                    LinkStyle::Gitweb => format!("{};a=commit;h={}", link, hash.as_ref()),
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gitweb_commit_link() {
+        let link = LinkStyle::Gitweb;
+        let hash = "deadbeef";
+        let commit = link.commit_link(hash, "http://example.com/gitweb/?p=foo.git");
+        assert_eq!(format!("http://example.com/gitweb/?p=foo.git;a=commit;h={}", &hash), commit);
+    }
+
+    #[test]
+    fn test_gitweb_issue_link() {
+       let link = LinkStyle::Gitweb;
+       let issue = link.issue_link("42", "http://example.com/gitweb/?p=foo.git");
+       assert_eq!("42", issue);
     }
 }


### PR DESCRIPTION
Gitweb uses a parameterized URL to link to the different repositories.
Since Gitweb cannot track issues `issue_link` just returns the issue
as does Cgit.