### PR TITLE
Make sections order contant.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "A conventional changelog for the rest of us"
 exclude = ["docs/*"]
 
 [dependencies]
+indexmap = "1.0.1"
 regex = "0.1.41"
 toml = "0.1.23"
 time = "0.1.33"

--- a/src/clog.rs
+++ b/src/clog.rs
@@ -7,6 +7,7 @@ use std::io::{stdout, BufWriter, Write, Read};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use indexmap::IndexMap;
 use regex::Regex;
 use toml::{Value, Parser};
 
@@ -59,7 +60,7 @@ pub struct Clog {
     pub outfile: Option<String>,
     /// Maps out the sections and aliases used to trigger those sections. The keys are the section
     /// name, and the values are an array of aliases.
-    pub section_map: HashMap<String, Vec<String>>,
+    pub section_map: IndexMap<String, Vec<String>>,
     /// The git dir with all the meta-data (Typically the `.git` sub-directory of the project)
     pub git_dir: Option<PathBuf>,
     /// The working directory of the git project (typically the project directory, or parent of the
@@ -126,7 +127,7 @@ impl fmt::Debug for Clog {
 impl Clog {
     fn _new() -> Clog {
         debugln!("Creating default clog with _new()");
-        let mut sections = HashMap::new();
+        let mut sections = IndexMap::new();
         sections.insert("Features".to_owned(), vec!["ft".to_owned(), "feat".to_owned()]);
         sections.insert("Bug Fixes".to_owned(), vec!["fx".to_owned(), "fix".to_owned()]);
         sections.insert("Performance".to_owned(), vec!["perf".to_owned()]);

--- a/src/fmt/json_writer.rs
+++ b/src/fmt/json_writer.rs
@@ -202,7 +202,10 @@ impl<'a> FormatWriter for JsonWriter<'a> {
         }
 
         write!(self.0, "\"sections\":").unwrap();
-        let mut s_it = sm.sections.iter().peekable();
+        let mut s_it = options.section_map
+            .keys()
+            .filter_map(|sec| sm.sections.get(sec).map(|compmap| (sec, compmap)))
+            .peekable();
         if s_it.peek().is_some() {
             debugln!("There are sections to write");
             write!(self.0, "[").unwrap();

--- a/src/fmt/md_writer.rs
+++ b/src/fmt/md_writer.rs
@@ -183,7 +183,12 @@ impl<'a> FormatWriter for MarkdownWriter<'a> {
         if let Some(..) = self.write_header(options).err() {
             return Err(Error::WriteErr);
         }
-        for (sec, secmap) in sm.sections.iter() {
+
+        // Get the section names ordered from `options.section_map`
+        let s_it = options.section_map
+            .keys()
+            .filter_map(|sec| sm.sections.get(sec).map(|secmap| (sec, secmap)));
+        for (sec, secmap) in s_it {
             try!(self.write_section(options, &sec[..], &secmap.iter().collect::<BTreeMap<_,_>>()));
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // DOCS
 
+extern crate indexmap;
 extern crate regex;
 extern crate toml;
 extern crate time;


### PR DESCRIPTION
Replace Clog.section_map by an indexmap::IndexMap to keep a consistent sections order between runs.
