### PR TITLE
fix: Use default sections if config file has no [sections]

### DIFF
--- a/examples/clog-only.toml
+++ b/examples/clog-only.toml
@@ -1,0 +1,48 @@
+[clog]
+# A repository link with the trailing '.git' which will be used to generate
+# all commit and issue links
+repository = "https://github.com/clog-tool/clog-lib"
+# A constant release title
+subtitle = "my awesome title"
+
+# specify the style of commit links to generate, defaults to "github" if omitted
+link-style = "github"
+
+# The preferred way to set a constant changelog. This file will be read for old changelog
+# data, then prepended to for new changelog data. It's the equivilant to setting
+# both infile and outfile to the same file.
+#
+# Do not use with outfile or infile fields!
+#
+# Defaults to stdout when omitted
+changelog = "mychangelog.md"
+
+# This sets an output file only! If it exists already, new changelog data will be
+# prepended, if not it will be created.
+#
+# This is useful in conjunction with the infile field if you have a separate file
+# that you would like to append after newly created clog data
+#
+# Defaults to stdout when omitted
+outfile = "MyChangelog.md"
+
+# This sets the input file old! Any data inside this file will be appended to any
+# new data that clog picks up
+#
+# This is useful in conjunction with the outfile field where you may wish to read
+# from one file and append that data to the clog output in another
+infile = "My_old_changelog.md"
+
+# This sets the output format. There are two options "json" or "markdown" and
+# defaults to "markdown" when omitted
+output-format = "json"
+
+# If you use tags, you can set the following if you wish to only pick
+# up changes since your latest tag
+from-latest-tag = true
+
+# The working or project directory
+git-work-tree = "/myproject"
+
+# the git metadata directory
+git-dir = "/myproject/.git"

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use crate::{fmt::ChangelogFormat, link_style::LinkStyle};
 pub struct RawCfg {
     pub clog: RawClogCfg,
     #[serde(default)]
-    pub sections: IndexMap<String, Vec<String>>,
+    pub sections: Option<IndexMap<String, Vec<String>>>,
     #[serde(default)]
     pub components: HashMap<String, Vec<String>>,
 }
@@ -33,7 +33,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn from_config() {
+    fn from_config_full() {
         let cfg = include_str!("../examples/clog.toml");
         let res = toml::from_str(cfg);
         assert!(res.is_ok(), "{res:?}");
@@ -52,18 +52,29 @@ mod tests {
         assert_eq!(cfg.clog.git_work_tree, Some("/myproject".into()));
         assert_eq!(cfg.clog.git_dir, Some("/myproject/.git".into()));
         assert!(cfg.clog.from_latest_tag);
+        assert!(cfg.sections.is_some());
         assert_eq!(
-            cfg.sections.get("MySection"),
+            cfg.sections.as_ref().unwrap().get("MySection"),
             Some(&vec!["mysec".into(), "ms".into()])
         );
         assert_eq!(
-            cfg.sections.get("Another Section"),
+            cfg.sections.as_ref().unwrap().get("Another Section"),
             Some(&vec!["another".into()])
         );
         assert_eq!(
             cfg.components.get("MyLongComponentName"),
             Some(&vec!["long".into(), "comp".into()])
         );
+    }
+
+    #[test]
+    fn from_config_no_sections() {
+        let cfg = include_str!("../examples/clog-only.toml");
+        let res = toml::from_str(cfg);
+        assert!(res.is_ok(), "{res:?}");
+        let cfg: RawCfg = res.unwrap();
+
+        assert!(cfg.sections.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Attempt to solve https://github.com/clog-tool/clog-cli/issues/103.

Though this will lead to a behaviour that's different from what https://github.com/clog-tool/clog-cli?tab=readme-ov-file#custom-sections describes, where it seems that config file `[sections]` should be merged into the default ones. If that's what should've happened, I'm happy to close this PR (and do another one if I find some time).